### PR TITLE
Ci/lint markdown link

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,21 @@ jobs:
         with:
           args: "**/*.md"
 
+  lint-markdown-link:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Lint markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          base-branch: "main"
+          check-modified-files-only: "no"
+          config-file: ".mlc_config.json"
+
   lint-yaml:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,29 @@ jobs:
       - name: Lint yaml files
         uses: ibiqlik/action-yamllint@v3.1.0
 
+  lint-json:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Lint json files
+        run: |
+          sudo apt install -y jsonlint
+          find ./ -type f -name "*.json" -exec sh -c '
+            for file do
+              if ! jsonlint-php -q "$file"; then
+                echo "❌ $file"
+                export FAILED=1
+              else
+                echo "✅ $file"
+              fi
+            done
+            if [ "${FAILED}" = "1" ]; then
+              exit 1
+            fi
+          ' sh {} +
+
   lint-branch-name:
     runs-on: ubuntu-20.04
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,18 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^https://www.linkedin.com/company/okp4-open-knowledge-protocol-for"
+        }
+    ],
+    "replacementPatterns": [
+        {
+            "pattern": "^/profile",
+            "replacement": "https://github.com/okp4/.github/raw/main/profile"
+        }
+    ],
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}


### PR DESCRIPTION
The PR adds 2 jobs to the existing `lint` workflow:

- ✔️ a check in markdown files for broken links using the [gaurav-nelson/github-action-markdown-link-check](https://github.com/marketplace/actions/markdown-link-check) action.
- ✔️ a lint for json files with the configuration specified in the [okp4/actions](https://github.com/okp4/actions/blob/main/src/.github/workflows/lint.yml#L50) repository.